### PR TITLE
Added node-watch to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "colors": "~0.6.1",
     "temp": "~0.5.1",
     "fs-extra": "~0.6.3",
-    "consolidate": "~0.9.1"
+    "consolidate": "~0.9.1",
+    "node-watch": "~0.3.4"
   },
   "author": "zhongchiyu@gmail.com",
   "license": "MIT",


### PR DESCRIPTION
Hi!

You've missed `node-watch` in your `package.json`. App fails without it:

```
module.js:340
    throw err;
    ^
Error: Cannot find module 'node-watch'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/share/npm/lib/node_modules/catlogjs/lib/cli.coffee:30:11)
    at Object.<anonymous> (/usr/local/share/npm/lib/node_modules/catlogjs/lib/cli.coffee:329:4)
    at Module._compile (module.js:456:26)
    at Object.loadFile (/usr/local/share/npm/lib/node_modules/catlogjs/node_modules/coffee-script/lib/coffee-script/coffee-script.js:182:19)
    at Module.load (/usr/local/share/npm/lib/node_modules/catlogjs/node_modules/coffee-script/lib/coffee-script/coffee-script.js:211:36)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/share/npm/lib/node_modules/catlogjs/bin/catlog:4:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```
